### PR TITLE
Changed input factor of max file size in settings to MB

### DIFF
--- a/src/Images/Helpers/IllustrationHelper.cs
+++ b/src/Images/Helpers/IllustrationHelper.cs
@@ -44,9 +44,13 @@ namespace Images
             return GetUploadRoot() + GetUploadDirectory();
         }
 
-        public int GetMaximumFileSize()
+        public int GetMaximumFileSizeMB()
         {
-            return _imagesSettings?.MaximumFileSize ?? 1048576;
+            return _imagesSettings?.MaximumFileSize ?? 10;
+        }
+
+        public int GetMaximumFileSizeBytes() {
+            return GetMaximumFileSizeMB() * 1024 * 1024;
         }
 
         public void DeleteFile(Illustration illustration)

--- a/src/Images/ViewModels/ConceptIllustrationPage.json.cs
+++ b/src/Images/ViewModels/ConceptIllustrationPage.json.cs
@@ -14,7 +14,7 @@ namespace Images
         {
             base.OnData();
 
-            MaxFileSize = Helper.GetMaximumFileSize();
+            MaxFileSize = Helper.GetMaximumFileSizeBytes();
 
             foreach (string s in UploadHandlers.AllowedMimeTypes) {
                 AllowedMimeTypes.Add().StringValue = s;

--- a/src/Images/ViewModels/ConceptPage.json.cs
+++ b/src/Images/ViewModels/ConceptPage.json.cs
@@ -9,7 +9,7 @@ namespace Images {
         protected override void OnData() {
             base.OnData();
 
-            this.MaxFileSize = helper.GetMaximumFileSize();
+            this.MaxFileSize = helper.GetMaximumFileSizeBytes();
 
             foreach (string s in UploadHandlers.AllowedMimeTypes) {
                 this.AllowedMimeTypes.Add().StringValue = s;

--- a/src/Images/ViewModels/IllustrationPage.json.cs
+++ b/src/Images/ViewModels/IllustrationPage.json.cs
@@ -13,7 +13,7 @@ namespace Images {
         protected override void OnData() {
             base.OnData();
 
-            this.MaxFileSize = helper.GetMaximumFileSize();
+            this.MaxFileSize = helper.GetMaximumFileSizeBytes();
             this.AllowedMimeTypes.Clear();
 
             foreach (string s in UploadHandlers.AllowedMimeTypes) {

--- a/src/Images/ViewModels/SettingsPage.json.cs
+++ b/src/Images/ViewModels/SettingsPage.json.cs
@@ -11,7 +11,7 @@ namespace Images {
                 var helper = new IllustrationHelper();
                 settings = new ImagesSettings
                 {
-                    MaximumFileSize = helper.GetMaximumFileSize(),
+                    MaximumFileSize = helper.GetMaximumFileSizeMB(),
                     UploadFolderPath = helper.GetUploadDirectory()
                 };
             }

--- a/src/Images/wwwroot/Images/elements/so-juicy-filedrop/juicy-filedrop.html
+++ b/src/Images/wwwroot/Images/elements/so-juicy-filedrop/juicy-filedrop.html
@@ -96,12 +96,22 @@ Add web socket support
                     return false;
                 }
                 if (file.size > this.maxfilesize) {
+                    var maxfilesizeKb = this.maxfilesize / 1024,
+                        maxfilesizeMb = maxfilesizeKb / 1024,
+                        maxfilesizeString = '';
+
+                    if (maxfilesizeKb > 1024) {
+                        maxfilesizeString = '' + parseFloat(maxfilesizeMb).toFixed(2) + 'MB';
+                    } else {
+                        maxfilesizeString = '' + parseFloat(maxfilesizeKb).toFixed(2) + 'KB';
+                    }
+
                     m = [
                         'File ',
                         file.name,
                         ' is too big. Maximum file size is: ',
-                        this.maxfilesize / 1024,
-                        'kb.'
+                        maxfilesizeString,
+                        '.'
                     ].join('');
                     this.fire('fileSelectError', {
                         file: file,

--- a/src/Images/wwwroot/Images/viewmodels/SettingsPage.html
+++ b/src/Images/wwwroot/Images/viewmodels/SettingsPage.html
@@ -3,7 +3,7 @@
         <h3>Images</h3>
         <label class="control-label" style="font-size: 12pt; margin: 0;">Upload folder path</label>
         <input type="text" value="{{model.UploadFolderPath$::input}}" class="form-control" style="width: 50%"/>
-        <label class="control-label" style="font-size: 12pt; margin: 10px 0 0 0;">Maximum file size (bytes)</label>
+        <label class="control-label" style="font-size: 12pt; margin: 10px 0 0 0;">Maximum file size (MB)</label>
         <input type="number" value="{{model.MaximumFileSize$::input}}" class="form-control" style="width: 50%"/>
         <button class="btn btn-small btn-success" style="margin-top: 20px;" onclick="++this.value;" value="{{model.Save$::click}}">Save</button>
     </template>


### PR DESCRIPTION
This is the fix for issue #41 

I also merged the (hopefully) accepted [fix](https://github.com/Juicy/juicy-filedrop/issues/2) for `juicy-filedrop`.

