### PR TITLE
Add MimeType information on startup

### DIFF
--- a/src/Images/Helpers/IllustrationHelper.cs
+++ b/src/Images/Helpers/IllustrationHelper.cs
@@ -136,13 +136,8 @@ namespace Images
         {
             foreach (var content in contents)
             {
-                var mimeType = MimeMapping.GetMimeMapping(content.URL);
-                if (mimeType != null)
-                {
-                    content.MimeType = mimeType;
-                }
+                content.MimeType = MimeMapping.GetMimeMapping(content.URL);
             }
-
         }
     }
 }

--- a/src/Images/Helpers/IllustrationHelper.cs
+++ b/src/Images/Helpers/IllustrationHelper.cs
@@ -4,6 +4,8 @@ using Starcounter;
 using Simplified.Ring1;
 using Simplified.Ring6;
 using System;
+using System.Web;
+using System.Collections.Generic;
 
 namespace Images
 {
@@ -128,6 +130,25 @@ namespace Images
             {
                 fi.Delete();
             }
+        }
+
+        public string GuessMimeTypeForFileName(string fileName)
+        {
+            string mimeType = MimeMapping.GetMimeMapping(fileName);
+            return mimeType;
+        }
+
+        public void GuessMimeTypeForContents(IEnumerable<Content> contents)
+        {
+            foreach (Content content in contents)
+            {
+                var mimeType = GuessMimeTypeForFileName(content.URL);
+                if (mimeType != null)
+                {
+                    content.MimeType = mimeType;
+                }
+            }
+
         }
     }
 }

--- a/src/Images/Helpers/IllustrationHelper.cs
+++ b/src/Images/Helpers/IllustrationHelper.cs
@@ -132,17 +132,11 @@ namespace Images
             }
         }
 
-        public string GuessMimeTypeForFileName(string fileName)
-        {
-            string mimeType = MimeMapping.GetMimeMapping(fileName);
-            return mimeType;
-        }
-
         public void GuessMimeTypeForContents(IEnumerable<Content> contents)
         {
-            foreach (Content content in contents)
+            foreach (var content in contents)
             {
-                var mimeType = GuessMimeTypeForFileName(content.URL);
+                var mimeType = MimeMapping.GetMimeMapping(content.URL);
                 if (mimeType != null)
                 {
                     content.MimeType = mimeType;

--- a/src/Images/Helpers/UpgradeData.cs
+++ b/src/Images/Helpers/UpgradeData.cs
@@ -5,17 +5,17 @@ namespace Images
 {
     public class UpgradeData
     {
-        /**
-         * In Images 3.0.6 and lower, the Content class did not include the image mime type information.
-         * It can be extrapolated from the file extension
-         */
+        /// <summary>
+        /// In Images 3.0.6 and lower, the Content class did not include the image mime type information.
+        /// It can be extrapolated from the file extension.
+        /// </summary>
         public void UpgradeMimeType()
         {
             var contents = Db.SQL<Content>("SELECT c FROM Simplified.Ring1.Content c WHERE c.MimeType IS NULL");
-            var _illustrationHelper = new IllustrationHelper();
+            var illustrationHelper = new IllustrationHelper();
             Db.Transact(() =>
             {
-                _illustrationHelper.GuessMimeTypeForContents(contents);
+                illustrationHelper.GuessMimeTypeForContents(contents);
             });
         }
     }

--- a/src/Images/Helpers/UpgradeData.cs
+++ b/src/Images/Helpers/UpgradeData.cs
@@ -1,0 +1,22 @@
+﻿using Simplified.Ring1;
+using Starcounter;
+
+namespace Images
+{
+    public class UpgradeData
+    {
+        /**
+         * In Images 3.0.6 and lower, the Content class did not include the image mime type information.
+         * It can be extrapolated from the file extension
+         */
+        public void UpgradeMimeType()
+        {
+            var contents = Db.SQL<Content>("SELECT c FROM Simplified.Ring1.Content c WHERE c.MimeType IS NULL");
+            var _illustrationHelper = new IllustrationHelper();
+            Db.Transact(() =>
+            {
+                _illustrationHelper.GuessMimeTypeForContents(contents);
+            });
+        }
+    }
+}

--- a/src/Images/Images.csproj
+++ b/src/Images/Images.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Api\MainHandlers.cs" />
     <Compile Include="Helpers\IllustrationHelper.cs" />
     <Compile Include="Helpers\ImageValidator.cs" />
+    <Compile Include="Helpers\UpgradeData.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ViewModels\ImagePage.json.cs">
       <DependentUpon>ImagePage.json</DependentUpon>

--- a/src/Images/Program.cs
+++ b/src/Images/Program.cs
@@ -1,9 +1,17 @@
+using Images.Helpers;
+using Simplified.Ring1;
+using Starcounter;
+
 namespace Images {
     class Program {
         static void Main() {
             var main = new MainHandlers();
 
             main.Register();
+
+            var upgrade = new UpgradeData();
+
+            upgrade.UpgradeMimeType();
         }
     }
 }


### PR DESCRIPTION
I have created a new `UpgradeData` class to help the data migration. `Content` created with Images app version 3.0.6 or lower does not hold the mime type information. With this change, the mime type information will be added wherever possible.

@aloscha pls review