### PR TITLE
Check mimemapping only for not empty strings

### DIFF
--- a/src/Images/Helpers/IllustrationHelper.cs
+++ b/src/Images/Helpers/IllustrationHelper.cs
@@ -134,7 +134,7 @@ namespace Images
 
         public void GuessMimeTypeForContents(IEnumerable<Content> contents)
         {
-            foreach (var content in contents)
+            foreach (var content in contents.Where(e => !string.IsNullOrEmpty(e.URL)))
             {
                 content.MimeType = MimeMapping.GetMimeMapping(content.URL);
             }


### PR DESCRIPTION
I've noticed that sometimes I've got nullreferenceexception because URL in MimeMapping is null.